### PR TITLE
1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@perry-rylance/event-dispatcher",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A lightweight ES6 event dispatcher which supports bubbling, capture phases and bubbling to the DOM tree.",
     "main": "event-dispatcher.js",
     "type": "module",


### PR DESCRIPTION
- Added support for eventDispatcherParent property, which can be used to override parent. Useful when using parent would collide with other libraries
- Fixed bug where removing one or more listeners during trigger function would cause listeners to be skipped